### PR TITLE
double defined  AC_CONFIG_MACRO_DIR([m4]) leads to errors in ./autoge…

### DIFF
--- a/veejay-current/veejay-core/configure.ac
+++ b/veejay-current/veejay-core/configure.ac
@@ -33,7 +33,7 @@ AC_SUBST(LT_AGE)
 dnl **********************************************************************
 dnl Options
 
-AC_CONFIG_MACRO_DIR([m4])
+#AC_CONFIG_MACRO_DIR([m4])
 
 
 dnl kill CFLAGS


### PR DESCRIPTION
This happens in all configure.ac files

…n.sh

/autogen.sh
autoreconf: export WARNINGS=
autoreconf: Entering directory '.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal -I m4 --force -I m4 
configure.ac:36: error: AC_CONFIG_MACRO_DIR can only be used once
./lib/autoconf/general.m4:1970: AC_CONFIG_MACRO_DIR is expanded from...
configure.ac:36: the top level
autom4te: error: /usr/bin/m4 failed with exit status: 1
aclocal: error: /usr/bin/autom4te failed with exit statu