### PR TITLE
progress build fix ....

### DIFF
--- a/veejay-current/veejay-server/thirdparty/bio2jack/bio2jack.c
+++ b/veejay-current/veejay-server/thirdparty/bio2jack/bio2jack.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <fcntl.h>
 #include <math.h>
 #include <unistd.h>

--- a/veejay-current/veejay-server/veejay/vj-perform.c
+++ b/veejay-current/veejay-server/veejay/vj-perform.c
@@ -2226,7 +2226,7 @@ int vj_perform_fill_audio_buffers(
     video_playback_setup *settings = info->settings;
     uint8_t *temporary_buffer = p->audio_render_buffer;
     uint8_t *downsample_buffer = p->down_sample_buffer;
-    performer_global_t *g = (performer_t*) info->performer;
+    performer_global_t *g = (performer_global_t*) info->performer;
     sample_b_t *sample_ptrB = &(g->A->sample_b);
     sample_b_t *sample_ptrA = &(g->A->sample_a);
     


### PR DESCRIPTION
only progress fix because build now stop at
```

vj-pjack.c: In function 'vj_jack_xrun_flag':
vj-pjack.c:106:16: error: implicit declaration of function 'JACK_XRUNHandled' [-Wimplicit-function-declaration]
  106 |         return JACK_XRUNHandled(driver);
      |                ^~~~~~~~~~~~~~~~
vj-pjack.c: In function 'vj_jack_get_ringbuffer_used':
vj-pjack.c:217:16: error: implicit declaration of function 'JACK_GetRingBufferUsed'; did you mean 'JACK_GetRingBufferSize'? [-Wimplicit-function-declaration]
  217 |         return JACK_GetRingBufferUsed(driver);
      |                ^~~~~~~~~~~~~~~~~~~~~~
      |                JACK_GetRingBufferSize
vj-pjack.c: In function 'vj_jack_client_to_jack_frames':
vj-pjack.c:221:16: error: implicit declaration of function 'JACK_GetClientToJackFrames' [-Wimplicit-function-declaration]
  221 |         return JACK_GetClientToJackFrames(driver,client_frames);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [Makefile:678: vj-pjack.lo] Error 1

```