### PR TITLE
Fix errors in fresh build

### DIFF
--- a/veejay-current/veejay-core/veejaycore/Makefile.am
+++ b/veejay-current/veejay-core/veejaycore/Makefile.am
@@ -13,7 +13,7 @@ AM_CPPFLAGS += -I /usr/X11R6/include \
 		-I$(top_srcdir)/libvjlzo \
 		-I$(top_srcdir)/libvjmsg \
 		-I$(top_srcdir)/libvjnet \
-		-I$(top_scrdir)/libyuv \
+		-I$(top_srcdir)/libyuv \
 		-I$(top_srcdir)/libvevo \
 		$(LIBAVFORMAT_CFLAGS) $(LIBAVCODEC_CFLAGS) $(LIBAVUTIL_CFLAGS) $(LIBSWSCALE_CFLAGS) $(GLIB_CFLAGS) \
 		$(PTHREAD_CFLAGS) 

--- a/veejay-current/veejay-core/veejaycore/avhelper.c
+++ b/veejay-current/veejay-core/veejaycore/avhelper.c
@@ -26,11 +26,11 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <veejaycore/defs.h>
-#include <veejaycore/vj-msg.h>
-#include <veejaycore/vjmem.h>
+#include <libvjmsg/vj-msg.h>
+#include <libvjmem/vjmem.h>
 #include <veejaycore/vj-task.h>
 
-#include <veejaycore/yuvconv.h>
+#include <libyuv/yuvconv.h>
 #include <libavutil/avutil.h>
 #include <libavcodec/avcodec.h>
 #include <libavcodec/version.h>
@@ -39,7 +39,7 @@
 #include <libavutil/imgutils.h>
 #include <veejaycore/avhelper.h>
 #include <veejaycore/av.h>
-#include <veejaycore/hash.h>
+#include <thirdparty/libhash/hash.h>
 
 #if LIBAVCODEC_VERSION_MAJOR >= 57
 #ifndef CODEC_ID_HAP

--- a/veejay-current/veejay-director/src/Makefile.am
+++ b/veejay-current/veejay-director/src/Makefile.am
@@ -17,6 +17,7 @@ veejay_director_CFLAGS = $(OP_CFLAGS)
 
 veejay_director_SOURCES = \
     veejay-director.c \
+    director-compat.h \
     director-client.c \
     director-client.h \
     director-wire.c \

--- a/veejay-current/veejay-server/thirdparty/bio2jack/Makefile.am
+++ b/veejay-current/veejay-server/thirdparty/bio2jack/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS=$(VEEJAY_CFLAGS)
+AM_CFLAGS=$(VEEJAY_CFLAGS) $(VEEJAYCORE_CFLAGS)
 noinst_LTLIBRARIES = libbio2jack4vj.la
 LIBS = @LIBS@ @PTHREAD_LIBS@ @JACK_LIBS@
 libbio2jack4vj_la_SOURCES = bio2jack.c bio2jack.h

--- a/veejay-current/veejay-server/veejay.pc.in
+++ b/veejay-current/veejay-server/veejay.pc.in
@@ -6,5 +6,6 @@ includedir=@includedir@
 Name: veejay
 Description: visual instrument and realtime video sampler
 Version: @VERSION@
-Libs: -L${libdir} -lveejay 
+Libs: -L${libdir} -lveejay -lveejaycore
 Cflags: -I${includedir}
+Requires: veejaycore >= @VERSION@


### PR DESCRIPTION
I met some errors when building veejay so this OR fix these.

There are two kind of errors like:

1. appear in simple fresh build
    - b3a18c25ad311311e6de2e4b943a86f7a4797392
    - 8e3efe055cd6cdaecdcfe89bfaa20c219c093ef2
    - 03dcecf37223d5b7c418d2b046ec3e38139e0e93
- appear in fresh build with changed prefix like `--prefix=/tmp/veejay-build-test`
    - 46e13b86eb5a0a8a105421e5c1e6915e1b531b5b
    - f188b0ddd395429534c179f08951bd9bf872c719

I used these scripts to build freshly in a Docker container:
  https://gist.github.com/t-sin/91b9f9811a49c8a1579abe9afe73c0e0